### PR TITLE
Add CurrencyMaster library

### DIFF
--- a/currencymaster/README.md
+++ b/currencymaster/README.md
@@ -1,0 +1,14 @@
+# CurrencyMaster
+
+A simple TypeScript library for converting currencies using the [exchangerate.host](https://exchangerate.host) API.
+
+## Usage
+
+```ts
+import { convertCurrency } from 'currencymaster';
+
+const result = await convertCurrency(10, 'USD', 'EUR');
+console.log(result); // "€9.20" (example)
+```
+
+The function returns a string with the converted amount prefixed by the correct symbol when known.

--- a/currencymaster/dist/index.d.ts
+++ b/currencymaster/dist/index.d.ts
@@ -1,0 +1,2 @@
+export declare function convertCurrency(amount: number, from: string, to: string): Promise<string>;
+export declare function currencySymbol(code: string): string;

--- a/currencymaster/dist/index.js
+++ b/currencymaster/dist/index.js
@@ -1,0 +1,36 @@
+export async function convertCurrency(amount, from, to) {
+    const response = await fetch(`https://api.exchangerate.host/latest?base=${from}&symbols=${to}`);
+    if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+    }
+    const data = await response.json();
+    const rate = data.rates[to];
+    if (typeof rate !== 'number') {
+        throw new Error(`Rate for currency '${to}' not found`);
+    }
+    const converted = amount * rate;
+    const symbol = currencySymbol(to);
+    return `${symbol}${converted.toFixed(2)}`;
+}
+export function currencySymbol(code) {
+    const symbols = {
+        USD: '$',
+        EUR: '€',
+        GBP: '£',
+        JPY: '¥',
+        CNY: '¥',
+        INR: '₹',
+        RUB: '₽',
+        KRW: '₩',
+        AUD: 'A$',
+        CAD: 'C$',
+        CHF: 'CHF',
+        HKD: 'HK$',
+        NZD: 'NZ$',
+        SGD: 'S$',
+        SEK: 'kr',
+        NOK: 'kr',
+        MXN: '$',
+    };
+    return symbols[code] || `${code} `;
+}

--- a/currencymaster/package.json
+++ b/currencymaster/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "currencymaster",
+  "version": "1.0.0",
+  "description": "Currency conversion library using exchangerate.host",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build",
+    "test": "node dist/index.js"
+  },
+  "keywords": ["currency", "conversion"],
+  "author": "",
+  "license": "MIT"
+}

--- a/currencymaster/src/index.ts
+++ b/currencymaster/src/index.ts
@@ -1,0 +1,37 @@
+export async function convertCurrency(amount: number, from: string, to: string): Promise<string> {
+  const response = await fetch(`https://api.exchangerate.host/latest?base=${from}&symbols=${to}`);
+  if (!response.ok) {
+    throw new Error(`API request failed with status ${response.status}`);
+  }
+  const data = await response.json();
+  const rate = data.rates[to];
+  if (typeof rate !== 'number') {
+    throw new Error(`Rate for currency '${to}' not found`);
+  }
+  const converted = amount * rate;
+  const symbol = currencySymbol(to);
+  return `${symbol}${converted.toFixed(2)}`;
+}
+
+export function currencySymbol(code: string): string {
+  const symbols: Record<string, string> = {
+    USD: '$',
+    EUR: '€',
+    GBP: '£',
+    JPY: '¥',
+    CNY: '¥',
+    INR: '₹',
+    RUB: '₽',
+    KRW: '₩',
+    AUD: 'A$',
+    CAD: 'C$',
+    CHF: 'CHF',
+    HKD: 'HK$',
+    NZD: 'NZ$',
+    SGD: 'S$',
+    SEK: 'kr',
+    NOK: 'kr',
+    MXN: '$',
+  };
+  return symbols[code] || `${code} `;
+}

--- a/currencymaster/tsconfig.json
+++ b/currencymaster/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `currencymaster` TypeScript currency conversion library
- compile TypeScript to JS
- document how to use the library

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d54722f54833192f6eaa04fbe8b27